### PR TITLE
Re-enable plugin for GeoGig in communityRelease

### DIFF
--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerContextBuilder.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerContextBuilder.java
@@ -16,7 +16,7 @@ import org.locationtech.geogig.di.PluginsModule;
 import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.impl.ContextBuilder;
-import org.locationtech.geogig.storage.GraphDatabase;
+import org.locationtech.geogig.storage.ConflictsDatabase;
 import org.locationtech.geogig.storage.IndexDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.PluginDefaults;
@@ -87,8 +87,8 @@ public class GeoServerContextBuilder extends ContextBuilder {
                     .newMapBinder(binder(), VersionedFormat.class, IndexDatabase.class)
                     .permitDuplicates();
 
-            MapBinder<VersionedFormat, GraphDatabase> graphPlugins = MapBinder
-                    .newMapBinder(binder(), VersionedFormat.class, GraphDatabase.class)
+            MapBinder<VersionedFormat, ConflictsDatabase> graphPlugins = MapBinder
+                    .newMapBinder(binder(), VersionedFormat.class, ConflictsDatabase.class)
                     .permitDuplicates();
 
             Iterable<StorageProvider> providers = StorageProvider.findProviders();

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerContextBuilder.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/config/GeoServerContextBuilder.java
@@ -96,7 +96,7 @@ public class GeoServerContextBuilder extends ContextBuilder {
             for (StorageProvider sp : providers) {
                 VersionedFormat objectDatabaseFormat = sp.getObjectDatabaseFormat();
                 VersionedFormat indexDatabaseFormat = sp.getIndexDatabaseFormat();
-                VersionedFormat graphDatabaseFormat = sp.getGraphDatabaseFormat();
+                VersionedFormat conflictsDatabaseFormat = sp.getConflictsDatabaseFormat();
                 VersionedFormat refsDatabaseFormat = sp.getRefsDatabaseFormat();
 
                 if (objectDatabaseFormat != null) {
@@ -105,8 +105,8 @@ public class GeoServerContextBuilder extends ContextBuilder {
                 if (indexDatabaseFormat != null) {
                     GeoServerContextBuilder.bind(indexPlugins, indexDatabaseFormat);
                 }
-                if (graphDatabaseFormat != null) {
-                    GeoServerContextBuilder.bind(graphPlugins, graphDatabaseFormat);
+                if (conflictsDatabaseFormat != null) {
+                    GeoServerContextBuilder.bind(graphPlugins, conflictsDatabaseFormat);
                 }
                 if (refsDatabaseFormat != null) {
                     GeoServerContextBuilder.bind(refPlugins, refsDatabaseFormat);

--- a/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
+++ b/src/community/geogig/src/main/java/org/geogig/geoserver/rest/GeoServerRepositoryProvider.java
@@ -4,6 +4,8 @@
  */
 package org.geogig.geoserver.rest;
 
+import static org.geogig.geoserver.config.GeoServerGeoGigRepositoryResolver.getURI;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -212,4 +214,12 @@ public class GeoServerRepositoryProvider implements RepositoryProvider {
         }
         return false;
     }
+
+    @Override
+    public String getMaskedLocationString(Repository repo, String repoName) {
+        // need to mask the location as "geoserver://<repoName>"
+        return getURI(repoName);
+    }
+
+
 }

--- a/src/community/pom.xml
+++ b/src/community/pom.xml
@@ -72,7 +72,7 @@
           <descriptor>release/ext-jdbcstore.xml</descriptor>
           <descriptor>release/ext-ncwms.xml</descriptor>
           <descriptor>release/ext-gwc-sqlite.xml</descriptor> 
-          <!-- <descriptor>release/ext-geogig.xml</descriptor> -->
+          <descriptor>release/ext-geogig.xml</descriptor>
           <descriptor>release/ext-oauth2-google.xml</descriptor>
           <descriptor>release/ext-oauth2-github.xml</descriptor>
           <descriptor>release/ext-oauth2-geonode.xml</descriptor>
@@ -222,7 +222,7 @@
         <module>wps-remote</module>
         <module>wps-jdbc</module>
         <module>release</module>
-        <!-- <module>geogig</module> -->
+        <module>geogig</module>
         <module>gwc-distributed</module>
         <module>jdbcstore</module>
         <module>gdal</module>

--- a/src/community/release/ext-geogig.xml
+++ b/src/community/release/ext-geogig.xml
@@ -15,12 +15,8 @@
             <include>gs-geogig-*.jar</include>
             <!-- GeoGig jars -->
             <include>geogig-*.jar</include>
-            <!-- GeoGig plugin uses SQLite JDBC driver by default for security logs -->
-            <include>sqlite-jdbc-*.jar</include>
             <!-- Hikari DB connection pool libs -->
             <include>HikariCP-*.jar</include>
-            <!-- GeoGig needs a newer postgresql (42.1.1) driver than the one included in GeoServer up to geoserver 2.11.x -->
-            <include>postgresql-*.jar</include>
             <!-- the plugin uses Logback for LogStore -->
             <include>logback*.jar</include>
             <!-- Guice injection libs -->
@@ -39,8 +35,6 @@
             <include>jcommander-*.jar</include>
             <!-- jansi libs -->
             <include>jansi-*.jar</include>
-            <!-- Restlet fileupload -->
-            <include>org.restlet.ext.fileupload-*.jar</include>
             <!-- GeoTools Geopackage libs -->
             <include>gt-geopkg-*.jar</include>
             <!-- JSONP (JSR-353) libs -->
@@ -49,9 +43,6 @@
         <excludes>
             <exclude>*test*</exclude>
             <exclude>*sources*</exclude>
-            <!-- GeoGig now needs version 42.1.1+, so explicitly exclude older versions -->
-            <exclude>postgresql-8.*</exclude>
-            <exclude>postgresql-9.*</exclude>
         </excludes>
     </fileSet>
   </fileSets>

--- a/src/community/release/pom.xml
+++ b/src/community/release/pom.xml
@@ -193,11 +193,11 @@
      <artifactId>gs-gwc-sqlite</artifactId>
      <version>${project.version}</version>
    </dependency>
-   <!-- <dependency>
+   <dependency>
      <groupId>org.geoserver.community</groupId>
      <artifactId>gs-geogig</artifactId>
      <version>${project.version}</version>
-   </dependency>. -->
+   </dependency>
    <!-- <dependency>
      <groupId>org.geoserver.community.backuprestore</groupId>
      <artifactId>gs-backup-restore-core</artifactId>


### PR DESCRIPTION
* uncomment the GeoGig plugin in the communityRelease profile
* sync with the GeoGig core GraphDatabase -> ConflictsDatabase change
* restore masking GeoGig repository location URIs in Web API requests